### PR TITLE
fix: Set type button on Google OAuth buttons

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -89,7 +89,7 @@ export default function LoginPage() {
             </div>
 
             <a href="/api/auth/google" className="block w-full">
-              <Button variant="outline" className="w-full">
+              <Button variant="outline" className="w-full" type="button">
                 {/* Placeholder for Google Icon - <GIcon className="mr-2 h-4 w-4" /> */}
                 Sign in with Google
               </Button>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -118,7 +118,7 @@ export default function RegisterPage() {
             </div>
 
             <a href="/api/auth/google" className="block w-full">
-              <Button variant="outline" className="w-full">
+              <Button variant="outline" className="w-full" type="button">
                 {/* Placeholder for Google Icon - <GIcon className="mr-2 h-4 w-4" /> */}
                 Sign up with Google
               </Button>


### PR DESCRIPTION
Set type="button" on the Google Sign-In/Sign-Up buttons on the login and register pages to prevent them from triggering validation or submission of the main email/password form.